### PR TITLE
Provided Docker Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ Basic Python wrapper for XFOIL.
 - [x] MIT License
 - [x] Python 3.8+
 
+**XFOIL Usage:**
+In order for this code to work `XFOIL` must be in the user's `PATH`.
+
+An easy way to run the code is through a Docker container, for example:
+
+```bash
+$ docker pull danielkelshaw/xfoil
+```
+
 **Example Usage:**
 
 ```python


### PR DESCRIPTION
Provided a short desciption that mentions `XFOIL` must be in the user's `PATH`.
Also mentioned how a Docker container could be used to run `XFOIL`.